### PR TITLE
Add featured mixes grid

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -190,6 +190,24 @@ const Home = () => {
               </div>
             </div>
           </div>
+          <div className="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            {featuredMixes.map((mix) => (
+              <Link
+                key={mix.title}
+                to={mix.link}
+                className="group rounded-xl overflow-hidden border border-border-secondary hover:shadow-md transition-shadow"
+              >
+                <div className="relative">
+                  <img src={mix.image} alt={mix.title} className="w-full aspect-video object-cover" />
+                  <mix.icon className="absolute top-3 right-3 w-6 h-6 text-white drop-shadow" />
+                </div>
+                <div className="p-4">
+                  <h4 className="text-title3 mb-1">{mix.title}</h4>
+                  <p className="text-subheadline text-foreground-secondary">{mix.subtitle}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- render `featuredMixes` in Home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a6bbdca848321b8db9107c089786a