### PR TITLE
Introduce Layout component

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return <div className="min-h-screen bg-black text-white pt-20">{children}</div>;
+};
+
+export default Layout;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,10 +1,11 @@
 
 import React from 'react';
 import { Download, Music, Users, Award } from 'lucide-react';
+import Layout from '../components/Layout';
 
 const About = () => {
   return (
-    <div className="min-h-screen bg-black text-white pt-20">
+    <Layout>
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-b from-gray-900 to-black">
         <div className="max-w-4xl mx-auto px-6">
@@ -185,7 +186,7 @@ const About = () => {
           </div>
         </div>
       </section>
-    </div>
+    </Layout>
   );
 };
 

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -2,12 +2,13 @@
 import React, { useState } from 'react';
 import { Play, AlertTriangle, FileText, Clock, Radio } from 'lucide-react';
 import AlphaThetaCercleLoreBlock from '../components/AlphaThetaCercleLoreBlock';
+import Layout from '../components/Layout';
 
 const DiscoAscension = () => {
   const [showConspiracy, setShowConspiracy] = useState(false);
 
   return (
-    <div className="min-h-screen bg-black text-white pt-20">
+    <Layout>
       {/* Hero Section with Warning */}
       <section className="py-20 bg-gradient-to-b from-red-900/20 to-black">
         <div className="max-w-4xl mx-auto px-6">
@@ -234,7 +235,7 @@ const DiscoAscension = () => {
           </div>
         </div>
       </section>
-    </div>
+    </Layout>
   );
 };
 

--- a/src/pages/NostalgiaTrap.tsx
+++ b/src/pages/NostalgiaTrap.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Play, Heart, AlertCircle, Clock, Music, Share } from 'lucide-react';
+import Layout from '../components/Layout';
 
 const NostalgiaTrap = () => {
   const [emotionalState, setEmotionalState] = useState('');
@@ -36,7 +37,7 @@ const NostalgiaTrap = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white pt-20">
+    <Layout>
       {/* Emotional Prompt Overlay */}
       {showPrompt && (
         <div className="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm flex items-center justify-center p-6">
@@ -280,7 +281,7 @@ const NostalgiaTrap = () => {
           </div>
         </div>
       </section>
-    </div>
+    </Layout>
   );
 };
 

--- a/src/pages/RoleModel.tsx
+++ b/src/pages/RoleModel.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { Play, Coffee, Zap, AlertTriangle, Clock, FileText, Radio } from 'lucide-react';
+import Layout from '../components/Layout';
 
 const RoleModel = () => {
   const [showLegalDisclaimer, setShowLegalDisclaimer] = useState(false);
@@ -32,7 +33,7 @@ const RoleModel = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-black text-white pt-20">
+    <Layout>
       {/* Hero Section with Chaotic Energy */}
       <section className="section-padding bg-gradient-to-b from-yellow-900/20 via-black to-black">
         <div className="content-container">
@@ -324,7 +325,7 @@ const RoleModel = () => {
           </div>
         </div>
       </section>
-    </div>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## Summary
- add new `Layout` component for consistent dark page styling
- wrap `About`, `NostalgiaTrap`, `RoleModel`, and `DiscoAscension` pages with `Layout`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a6ec601a4832182926e3dcf5b5dc3