### PR TITLE
Improve accessibility for icon-only buttons

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -77,6 +77,7 @@ const Navigation = () => {
           {/* Mobile menu button */}
           <button
             onClick={() => setIsOpen(!isOpen)}
+            aria-label={isOpen ? 'Close navigation menu' : 'Open navigation menu'}
             className="md:hidden p-2 text-foreground-secondary hover:text-foreground transition-colors"
           >
             {isOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -82,6 +82,7 @@ const ToastClose = React.forwardRef<
     {...props}
   >
     <X className="h-4 w-4" />
+    <span className="sr-only">Close notification</span>
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -41,7 +41,10 @@ const DiscoAscension = () => {
                 <h3 className="text-2xl font-bold text-amber-500 mb-2">The Last Known Copy</h3>
                 <p className="text-gray-300">Recovered from the Groove Singularity incident</p>
               </div>
-              <button className="w-16 h-16 bg-amber-500 rounded-full flex items-center justify-center hover:bg-amber-400 transition-colors transform hover:scale-105">
+              <button
+                aria-label="Play Disco Ascension mix"
+                className="w-16 h-16 bg-amber-500 rounded-full flex items-center justify-center hover:bg-amber-400 transition-colors transform hover:scale-105"
+              >
                 <Play className="w-8 h-8 text-black ml-1" />
               </button>
             </div>

--- a/src/pages/NostalgiaTrap.tsx
+++ b/src/pages/NostalgiaTrap.tsx
@@ -119,7 +119,10 @@ const NostalgiaTrap = () => {
                   <span>59:14 of pure emotional chaos</span>
                 </div>
               </div>
-              <button className="w-20 h-20 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-300 shadow-2xl">
+              <button
+                aria-label="Play Nostalgia Trap mix"
+                className="w-20 h-20 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-300 shadow-2xl"
+              >
                 <Play className="w-10 h-10 text-white ml-1" />
               </button>
             </div>

--- a/src/pages/RoleModel.tsx
+++ b/src/pages/RoleModel.tsx
@@ -123,7 +123,10 @@ const RoleModel = () => {
                   <span>62:54 of beautiful chaos</span>
                 </div>
               </div>
-              <button className="w-20 h-20 bg-gradient-to-r from-yellow-500 to-red-500 rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-300 shadow-2xl group">
+              <button
+                aria-label="Play Role Model mix"
+                className="w-20 h-20 bg-gradient-to-r from-yellow-500 to-red-500 rounded-full flex items-center justify-center hover:scale-110 transition-transform duration-300 shadow-2xl group"
+              >
                 <Play className="w-10 h-10 text-white ml-1 group-hover:scale-110 transition-transform" />
               </button>
             </div>


### PR DESCRIPTION
## Summary
- add aria labels to play buttons on mix pages
- label mobile menu toggle button
- include screen reader text for toast close button

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a761b0b348321919859aadc6fc2c4