### PR TITLE
Add reusable Tracklist component

### DIFF
--- a/src/components/Tracklist.tsx
+++ b/src/components/Tracklist.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export interface TrackItem {
+  title: string;
+  artist?: string;
+  time?: string;
+}
+
+interface TracklistProps {
+  tracks: TrackItem[];
+  className?: string;
+  itemClassName?: string;
+  indexClassName?: string;
+  timeClassName?: string;
+}
+
+const Tracklist: React.FC<TracklistProps> = ({
+  tracks,
+  className = '',
+  itemClassName = '',
+  indexClassName = '',
+  timeClassName = '',
+}) => {
+  return (
+    <div className={`space-y-4 ${className}`.trim()}>
+      {tracks.map((track, index) => (
+        <div
+          key={index}
+          className={`flex items-center gap-4 p-4 rounded-xl transition-colors ${itemClassName}`.trim()}
+        >
+          <div
+            className={`w-8 h-8 rounded-full flex items-center justify-center font-mono text-sm ${indexClassName}`.trim()}
+          >
+            {index + 1}
+          </div>
+          <div className="flex-grow">
+            <div className="text-callout text-white font-medium">{track.title}</div>
+            {track.artist && (
+              <div className="text-subheadline text-gray-400">{track.artist}</div>
+            )}
+          </div>
+          {track.time && (
+            <div className={`text-subheadline font-mono ${timeClassName}`.trim()}>{track.time}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Tracklist;

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -3,9 +3,20 @@ import React, { useState } from 'react';
 import { Play, AlertTriangle, FileText, Clock, Radio } from 'lucide-react';
 import AlphaThetaCercleLoreBlock from '../components/AlphaThetaCercleLoreBlock';
 import Layout from '../components/Layout';
+import Tracklist from '../components/Tracklist';
 
 const DiscoAscension = () => {
   const [showConspiracy, setShowConspiracy] = useState(false);
+
+  const tracklist = [
+    { title: 'Opening Transmission - [CLASSIFIED]' },
+    { title: 'Temporal Loop Genesis - Artist Unknown' },
+    { title: 'Disco Paradox Formation - [REDACTED]' },
+    { title: 'Reality Restructure Sequence - Government Property' },
+    { title: 'The Groove Singularity - Zack Bissell Original' },
+    { title: 'Containment Breach Protocol - [DATA CORRUPTED]' },
+    { title: 'Final Transmission - Brooklyn Underground' },
+  ];
 
   return (
     <Layout>
@@ -189,25 +200,12 @@ const DiscoAscension = () => {
               </p>
             </div>
 
-            {/* Placeholder for tracklist - would be populated with actual tracks */}
-            <div className="space-y-3">
-              {[
-                "Opening Transmission - [CLASSIFIED]",
-                "Temporal Loop Genesis - Artist Unknown",
-                "Disco Paradox Formation - [REDACTED]",
-                "Reality Restructure Sequence - Government Property",
-                "The Groove Singularity - Zack Bissell Original",
-                "Containment Breach Protocol - [DATA CORRUPTED]",
-                "Final Transmission - Brooklyn Underground"
-              ].map((track, index) => (
-                <div key={index} className="flex items-center gap-4 p-3 hover:bg-amber-500/10 rounded-lg transition-colors">
-                  <div className="w-8 h-8 bg-amber-500/20 rounded flex items-center justify-center text-amber-500 font-mono text-sm">
-                    {index + 1}
-                  </div>
-                  <div className="text-gray-200 font-mono">{track}</div>
-                </div>
-              ))}
-            </div>
+            <Tracklist
+              tracks={tracklist}
+              className="space-y-3"
+              itemClassName="hover:bg-amber-500/10 p-3"
+              indexClassName="bg-amber-500/20 text-amber-500"
+            />
 
             <div className="mt-8 p-4 bg-red-900/20 border border-red-500/30 rounded-lg">
               <p className="text-red-200 text-sm">

--- a/src/pages/NostalgiaTrap.tsx
+++ b/src/pages/NostalgiaTrap.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { Play, Heart, AlertCircle, Clock, Music, Share } from 'lucide-react';
 import Layout from '../components/Layout';
+import Tracklist from '../components/Tracklist';
 
 const NostalgiaTrap = () => {
   const [emotionalState, setEmotionalState] = useState('');
@@ -239,20 +240,12 @@ const NostalgiaTrap = () => {
           </h2>
 
           <div className="world-card p-8">
-            <div className="space-y-4">
-              {tracklist.map((track, index) => (
-                <div key={index} className="flex items-center gap-4 p-4 hover:bg-purple-500/10 rounded-xl transition-colors group">
-                  <div className="w-8 h-8 bg-purple-500/20 rounded-full flex items-center justify-center text-purple-400 font-mono text-sm group-hover:bg-purple-500/30">
-                    {index + 1}
-                  </div>
-                  <div className="flex-grow">
-                    <div className="text-callout text-white font-medium">{track.title}</div>
-                    <div className="text-subheadline text-gray-400">{track.artist}</div>
-                  </div>
-                  <div className="text-subheadline text-amber-500 font-mono">{track.time}</div>
-                </div>
-              ))}
-            </div>
+            <Tracklist
+              tracks={tracklist}
+              itemClassName="hover:bg-purple-500/10 group"
+              indexClassName="bg-purple-500/20 text-purple-400 group-hover:bg-purple-500/30"
+              timeClassName="text-amber-500"
+            />
 
             <div className="mt-8 p-6 bg-red-900/20 border border-red-500/30 rounded-xl">
               <p className="text-red-200 text-callout">

--- a/src/pages/RoleModel.tsx
+++ b/src/pages/RoleModel.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { Play, Coffee, Zap, AlertTriangle, Clock, FileText, Radio } from 'lucide-react';
 import Layout from '../components/Layout';
+import Tracklist from '../components/Tracklist';
 
 const RoleModel = () => {
   const [showLegalDisclaimer, setShowLegalDisclaimer] = useState(false);
@@ -283,20 +284,13 @@ const RoleModel = () => {
               </p>
             </div>
 
-            <div className="space-y-3">
-              {tracklist.map((track, index) => (
-                <div key={index} className="flex items-center gap-4 p-3 hover:bg-yellow-500/10 rounded-lg transition-colors group">
-                  <div className="w-8 h-8 bg-yellow-500/20 rounded-full flex items-center justify-center text-yellow-400 font-mono text-sm group-hover:bg-yellow-500/30">
-                    {index + 1}
-                  </div>
-                  <div className="flex-grow">
-                    <div className="text-callout text-white font-medium">{track.title}</div>
-                    <div className="text-subheadline text-gray-400">{track.artist}</div>
-                  </div>
-                  <div className="text-subheadline text-amber-500 font-mono">{track.time}</div>
-                </div>
-              ))}
-            </div>
+            <Tracklist
+              tracks={tracklist}
+              className="space-y-3"
+              itemClassName="hover:bg-yellow-500/10 group p-3"
+              indexClassName="bg-yellow-500/20 text-yellow-400 group-hover:bg-yellow-500/30"
+              timeClassName="text-amber-500"
+            />
 
             <div className="mt-8 p-6 bg-yellow-900/20 border border-yellow-500/30 rounded-xl">
               <p className="text-yellow-200 text-callout">


### PR DESCRIPTION
## Summary
- create new `Tracklist` component
- display tracklists using the new component on Nostalgia Trap, Role Model and Disco Ascension pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a785736cc832186ae77966c068efb