### PR TITLE
Add React Helmet for dynamic titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-helmet": "^6.1.0",
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -6080,6 +6081,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.53.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
@@ -6189,6 +6211,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-smooth": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-helmet": "^6.1.0",
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Navigation from "./components/Navigation";
 import Footer from "./components/Footer";
+import ComingSoon from "./components/ComingSoon";
 import Home from "./pages/Home";
 import About from "./pages/About";
 import DiscoAscension from "./pages/DiscoAscension";
@@ -30,14 +31,14 @@ const App = () => (
             <Route path="/nostalgia-trap" element={<NostalgiaTrap />} />
             <Route path="/role-model" element={<RoleModel />} />
             {/* Placeholder routes for other pages */}
-            <Route path="/house-work" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">House Work: Elevation - Coming Soon</h1></div>} />
-            <Route path="/brooklyn-445" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">4:45 Somewhere in Brooklyn - Coming Soon</h1></div>} />
-            <Route path="/voyage" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Voyage - Coming Soon</h1></div>} />
-            <Route path="/return-to-senders" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Return to Senders - Coming Soon</h1></div>} />
-            <Route path="/watch" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Watch - Coming Soon</h1></div>} />
-            <Route path="/press" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Press & Testimonials - Coming Soon</h1></div>} />
-            <Route path="/lab-obsidian" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Lab Obsidian - Coming Soon</h1></div>} />
-            <Route path="/booking" element={<div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center"><h1 className="text-title1">Booking - Coming Soon</h1></div>} />
+            <Route path="/house-work" element={<ComingSoon title="House Work: Elevation" />} />
+            <Route path="/brooklyn-445" element={<ComingSoon title="4:45 Somewhere in Brooklyn" />} />
+            <Route path="/voyage" element={<ComingSoon title="Voyage" />} />
+            <Route path="/return-to-senders" element={<ComingSoon title="Return to Senders" />} />
+            <Route path="/watch" element={<ComingSoon title="Watch" />} />
+            <Route path="/press" element={<ComingSoon title="Press & Testimonials" />} />
+            <Route path="/lab-obsidian" element={<ComingSoon title="Lab Obsidian" />} />
+            <Route path="/booking" element={<ComingSoon title="Booking" />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
           <Footer />

--- a/src/components/ComingSoon.tsx
+++ b/src/components/ComingSoon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+interface ComingSoonProps {
+  title: string;
+}
+
+const ComingSoon = ({ title }: ComingSoonProps) => (
+  <>
+    <Helmet>
+      <title>{title} – Zack Bissell</title>
+    </Helmet>
+    <div className="min-h-screen bg-white text-foreground pt-20 flex items-center justify-center">
+      <h1 className="text-title1">{title} - Coming Soon</h1>
+    </div>
+  </>
+);
+
+export default ComingSoon;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,11 +1,15 @@
 
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { Download, Music, Users, Award } from 'lucide-react';
 import Layout from '../components/Layout';
 
 const About = () => {
   return (
     <Layout>
+      <Helmet>
+        <title>About – Zack Bissell</title>
+      </Helmet>
       {/* Hero Section */}
       <section className="py-20 bg-gradient-to-b from-gray-900 to-black">
         <div className="max-w-4xl mx-auto px-6">

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
 import { Play, AlertTriangle, FileText, Clock, Radio } from 'lucide-react';
 import AlphaThetaCercleLoreBlock from '../components/AlphaThetaCercleLoreBlock';
 import Layout from '../components/Layout';
@@ -20,6 +21,9 @@ const DiscoAscension = () => {
 
   return (
     <Layout>
+      <Helmet>
+        <title>Disco Ascension – Zack Bissell</title>
+      </Helmet>
       {/* Hero Section with Warning */}
       <section className="py-20 bg-gradient-to-b from-red-900/20 to-black">
         <div className="max-w-4xl mx-auto px-6">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import { Play, ArrowRight, Music, Calendar, Zap, Heart, AlertTriangle } from 'lucide-react';
 import InterceptedTranscript from '../components/InterceptedTranscript';
 import { Link } from 'react-router-dom';
@@ -64,7 +65,11 @@ const Home = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-white">
+    <>
+      <Helmet>
+        <title>Home – Zack Bissell</title>
+      </Helmet>
+      <div className="min-h-screen bg-white">
       {/* Hero Section - Editorial Style */}
       <section className="pt-24 pb-16">
         <div className="content-container">
@@ -263,6 +268,7 @@ const Home = () => {
         />
       </section>
     </div>
+  </>
   );
 };
 

--- a/src/pages/NostalgiaTrap.tsx
+++ b/src/pages/NostalgiaTrap.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import { Play, Heart, AlertCircle, Clock, Music, Share } from 'lucide-react';
 import Layout from '../components/Layout';
 import Tracklist from '../components/Tracklist';
@@ -39,6 +40,9 @@ const NostalgiaTrap = () => {
 
   return (
     <Layout>
+      <Helmet>
+        <title>Nostalgia Trap – Zack Bissell</title>
+      </Helmet>
       {/* Emotional Prompt Overlay */}
       {showPrompt && (
         <div className="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm flex items-center justify-center p-6">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Helmet } from "react-helmet";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,15 +13,20 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <>
+      <Helmet>
+        <title>404 – Zack Bissell</title>
+      </Helmet>
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold mb-4">404</h1>
+          <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+          <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+            Return to Home
+          </a>
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/RoleModel.tsx
+++ b/src/pages/RoleModel.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet';
 import { Play, Coffee, Zap, AlertTriangle, Clock, FileText, Radio } from 'lucide-react';
 import Layout from '../components/Layout';
 import Tracklist from '../components/Tracklist';
@@ -35,6 +36,9 @@ const RoleModel = () => {
 
   return (
     <Layout>
+      <Helmet>
+        <title>Role Model – Zack Bissell</title>
+      </Helmet>
       {/* Hero Section with Chaotic Energy */}
       <section className="section-padding bg-gradient-to-b from-yellow-900/20 via-black to-black">
         <div className="content-container">


### PR DESCRIPTION
## Summary
- add `react-helmet` dependency
- provide a `ComingSoon` component for placeholder pages
- set `<title>` tags using React Helmet in each route component
- update router to use the new ComingSoon component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7952c4708321a0b80595f176b619