### PR TITLE
Fix failing Layout test

### DIFF
--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen } from '@testing-library/react';
-import Layout from '../Layout';
+import Layout from '../global/Layout';
+import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 
 describe('Layout', () => {
   it('renders children', () => {
     render(
-      <Layout>
-        <div>Test Child</div>
-      </Layout>
+      <MemoryRouter>
+        <Layout>
+          <div>Test Child</div>
+        </Layout>
+      </MemoryRouter>
     );
     expect(screen.getByText('Test Child')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- correct test path for Layout component
- wrap Layout in MemoryRouter for testing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684abc9b0ef88321b130d8da43e81291