### PR TITLE
Use stable key for tracklist items

### DIFF
--- a/src/components/ui/Tracklist.tsx
+++ b/src/components/ui/Tracklist.tsx
@@ -25,7 +25,7 @@ const Tracklist: React.FC<TracklistProps> = ({
     <div className={`space-y-4 ${className}`.trim()}>
       {tracks.map((track, index) => (
         <div
-          key={index}
+          key={track.title}
           className={`flex items-center gap-4 p-4 rounded-xl transition-colors ${itemClassName}`.trim()}
         >
           <div


### PR DESCRIPTION
## Summary
- improve stability of Tracklist rendering keys

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684abf75979c83219814f78124a45b69