### PR TITLE
Add tests for main pages

### DIFF
--- a/src/pages/__tests__/DiscoAscension.test.tsx
+++ b/src/pages/__tests__/DiscoAscension.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import DiscoAscension from '../DiscoAscension';
+
+describe('DiscoAscension page', () => {
+  it('shows hero heading and toggles incident log', async () => {
+    render(
+      <MemoryRouter>
+        <DiscoAscension />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { name: /disco ascension/i })).toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: /show log/i });
+    await userEvent.click(toggle);
+    expect(screen.getByText(/disco ball manifestation/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import Home from '../Home';
+
+describe('Home page', () => {
+  it('renders hero heading and CTA links', () => {
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { name: /it all begins/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /media page/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /epk download/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/NostalgiaTrap.test.tsx
+++ b/src/pages/__tests__/NostalgiaTrap.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import NostalgiaTrap from '../NostalgiaTrap';
+
+describe('NostalgiaTrap page', () => {
+  it('displays intro prompt and handles dismissal', async () => {
+    render(
+      <MemoryRouter>
+        <NostalgiaTrap />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { name: /before you enter/i })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /i'm ready to remember/i }));
+    expect(screen.getByRole('heading', { name: /how are you feeling right now/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/RoleModel.test.tsx
+++ b/src/pages/__tests__/RoleModel.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
+import RoleModel from '../RoleModel';
+
+describe('RoleModel page', () => {
+  it('renders hero heading and reveals legal notes', async () => {
+    render(
+      <MemoryRouter>
+        <RoleModel />
+      </MemoryRouter>
+    );
+    expect(screen.getByRole('heading', { name: /role model/i })).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: /show legal notes/i });
+    await userEvent.click(btn);
+    expect(screen.getByRole('heading', { name: /legal notes, probably/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Home, Disco Ascension, Nostalgia Trap, and Role Model pages
- verify rendering of important UI and interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac084c62883219c070a3f90edbbf2