### PR TITLE
Extend Disco Ascension components

### DIFF
--- a/src/components/worlds/disco-ascension/AudioPlayerDisco.tsx
+++ b/src/components/worlds/disco-ascension/AudioPlayerDisco.tsx
@@ -1,16 +1,69 @@
-interface AudioPlayerProps {
-  src: string;
+import { Play } from 'lucide-react';
+import { useRef, useState, useEffect } from 'react';
+
+interface Incident {
+  time: string;
+  event: string;
+  details: string;
 }
 
-export default function AudioPlayerDisco({ src }: AudioPlayerProps) {
+interface Props {
+  src: string;
+  incidents: Incident[];
+}
+
+function timeToSeconds(t: string) {
+  const parts = t.split(':').map(Number);
+  if (parts.length === 3) {
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  }
+  return parts[0] * 60 + parts[1];
+}
+
+export default function AudioPlayerDisco({ src, incidents }: Props) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [current, setCurrent] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onTime = () => setCurrent(audio.currentTime);
+    const onLoaded = () => setDuration(audio.duration);
+    audio.addEventListener('timeupdate', onTime);
+    audio.addEventListener('loadedmetadata', onLoaded);
+    return () => {
+      audio.removeEventListener('timeupdate', onTime);
+      audio.removeEventListener('loadedmetadata', onLoaded);
+    };
+  }, []);
+
   return (
-    <div className="border border-foreground/20 rounded-lg shadow-lg overflow-hidden aspect-video">
-      <iframe
-        title="Disco Ascension Mix"
-        src={src}
-        loading="lazy"
-        className="w-full h-full"
-      />
+    <div className="world-card p-8 relative crt-overlay">
+      <h3 className="text-title2 text-amber-500 mb-4">The Last Known Copy</h3>
+      <audio ref={audioRef} src={src} className="w-full mb-6" controls />
+      <div className="relative h-2 bg-gray-700 rounded mb-6">
+        <div
+          className="absolute top-0 left-0 h-2 bg-amber-500"
+          style={{ width: duration ? `${(current / duration) * 100}%` : '0%' }}
+        />
+        {incidents.map((inc, i) => {
+          const pos = duration ? (timeToSeconds(inc.time) / duration) * 100 : 0;
+          return (
+            <div
+              key={i}
+              className="absolute top-0 h-2 w-px bg-red-500"
+              style={{ left: `${pos}%` }}
+            />
+          );
+        })}
+      </div>
+      <div className="bg-black/40 backdrop-blur-md rounded p-6 text-center">
+        <p className="text-body text-gray-300 mb-4">Mixcloud embed coming soon.</p>
+        <button className="w-16 h-16 bg-amber-500/20 border border-amber-500/30 rounded-full flex items-center justify-center mx-auto">
+          <Play className="w-8 h-8 text-amber-400" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/worlds/disco-ascension/HeroDisco.tsx
+++ b/src/components/worlds/disco-ascension/HeroDisco.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import { AlertTriangle } from 'lucide-react';
 
 interface HeroProps {
   content: { title: string; tagline: string; warning: string };
@@ -9,13 +10,19 @@ export default function HeroDisco({ content }: HeroProps) {
     <motion.section
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="text-center py-20"
+      className="text-center section-padding"
     >
-      <h1 className="text-heading-1 bg-gradient-to-r from-amber-400 to-red-500 bg-clip-text text-transparent font-grotesque mb-4">
+      <div className="inline-flex items-center gap-2 bg-red-500/20 border border-red-500/30 rounded-full px-4 py-2 mb-6 animate-pulse">
+        <AlertTriangle className="w-5 h-5 text-red-400" />
+        <span className="text-red-300 font-semibold text-sm">CLASSIFIED MATERIAL</span>
+      </div>
+      <h1 className="text-heading-1 bg-gradient-to-r from-amber-400 via-orange-500 to-red-500 bg-clip-text text-transparent font-grotesque mb-4">
         {content.title}
       </h1>
       <p className="text-heading-2 mb-6">{content.tagline}</p>
-      <p className="text-body text-subtle max-w-xl mx-auto">{content.warning}</p>
+      <div className="max-w-xl mx-auto bg-red-900/20 border border-red-500/30 p-4 rounded">
+        <p className="text-body text-red-200">{content.warning}</p>
+      </div>
     </motion.section>
   );
 }

--- a/src/components/worlds/disco-ascension/IncidentLog.tsx
+++ b/src/components/worlds/disco-ascension/IncidentLog.tsx
@@ -16,12 +16,12 @@ export default function IncidentLog({ log }: LogProps) {
     <div className="my-8">
       <button
         onClick={() => setOpen(!open)}
-        className="mb-4 px-4 py-2 border rounded"
+        className="mb-4 px-4 py-2 border border-green-500/30 rounded bg-green-500/10 font-mono text-green-300"
       >
-        {open ? 'Hide Log' : 'Show Log'}
+        {open ? 'Hide Files' : 'Access Classified Research Files'}
       </button>
       {open && (
-        <div className="bg-black text-green-400 font-mono space-y-2 p-4">
+        <div className="bg-black text-green-400 font-mono space-y-2 p-4 border border-green-500/30 animate-fade-in">
           {log.map((item, idx) => (
             <div key={idx} className="border-b border-green-700/30 py-1">
               <span className="mr-2">[{item.time}]</span>

--- a/src/components/worlds/disco-ascension/ShareCTA.tsx
+++ b/src/components/worlds/disco-ascension/ShareCTA.tsx
@@ -1,0 +1,17 @@
+export default function ShareCTA() {
+  return (
+    <section className="section-padding bg-black text-center">
+      <div className="content-container">
+        <h2 className="text-title1 mb-8 text-white">Spread the Anomaly</h2>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <button className="px-6 py-3 bg-amber-500/20 border border-amber-500/30 rounded text-amber-400">
+            Share the Anomaly
+          </button>
+          <button className="px-6 py-3 bg-red-500/20 border border-red-500/30 rounded text-red-400">
+            Report to Authorities
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/worlds/disco-ascension/TracklistDisco.tsx
+++ b/src/components/worlds/disco-ascension/TracklistDisco.tsx
@@ -14,8 +14,18 @@ interface Props {
 
 export default function TracklistDisco({ tracks }: Props) {
   return (
-    <Tracklist
-      tracks={tracks.map(t => ({ title: t.redacted ? '[CLASSIFIED]' : t.title, artist: t.artist, time: t.timestamp }))}
-    />
+    <div className="world-card p-8 bg-white/5 backdrop-blur-md">
+      <h3 className="text-title2 text-amber-500 mb-6">Declassified Tracklist</h3>
+      <Tracklist
+        tracks={tracks.map(t => ({
+          title: t.redacted ? '[CLASSIFIED]' : t.title,
+          artist: t.artist,
+          time: t.timestamp,
+        }))}
+        itemClassName="hover:bg-amber-500/10"
+        indexClassName="bg-amber-500/20 text-amber-400"
+        timeClassName="text-red-400"
+      />
+    </div>
   );
 }

--- a/src/content/discoAscensionData.ts
+++ b/src/content/discoAscensionData.ts
@@ -1,14 +1,54 @@
 export const incidentLog = [
-  { time: "03:15 AM", event: "Disco Ball Manifestation", details: "A previously non-existent disco ball materialized..." },
+  {
+    time: "00:00",
+    event: "Power Spike",
+    details: "Venue lights surged as the mix began."
+  },
+  {
+    time: "03:15",
+    event: "Disco Ball Manifestation",
+    details: "A previously non-existent disco ball materialized above the crowd."
+  },
+  {
+    time: "25:42",
+    event: "Peak Paradox Event",
+    details: "Dancers reported moving in two timelines simultaneously."
+  },
+  {
+    time: "48:00",
+    event: "Containment Breach",
+    details:
+      "ETAB transcripts mention AlphaTheta memo: 'Mochakk didn\u2019t touch the Key Sync at all'."
+  }
 ];
 
 export const tracklist = [
-  { number: 1, title: "Can't Get Enough", artist: "Purple Disco Machine", redacted: false, timestamp: "00:00:00" },
-  { number: 2, title: "<REDACTED>", artist: "CLASSIFIED", redacted: true, timestamp: "00:04:20" },
+  {
+    number: 1,
+    title: "Can't Get Enough",
+    artist: "Purple Disco Machine",
+    redacted: false,
+    timestamp: "00:00"
+  },
+  {
+    number: 2,
+    title: "Midnight Paradox",
+    artist: "Zack Bissell",
+    redacted: false,
+    timestamp: "04:20"
+  },
+  {
+    number: 3,
+    title: "[CLASSIFIED]",
+    artist: "UNKNOWN",
+    redacted: true,
+    timestamp: "10:00"
+  }
 ];
 
 export const heroContent = {
   title: "Disco Ascension",
   tagline: "CLASSIFIED DOSSIER // EYES ONLY",
-  warning: "This transmission contains anomalous temporal frequencies. Listen with caution."
+  warning:
+    "ETAB advisory: anomalous frequencies detected. AlphaTheta memo states: 'Mochakk didn\u2019t touch the Key Sync at all.'"
 };

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -3,17 +3,19 @@ import HeroDisco from '../components/worlds/disco-ascension/HeroDisco';
 import AudioPlayerDisco from '../components/worlds/disco-ascension/AudioPlayerDisco';
 import IncidentLog from '../components/worlds/disco-ascension/IncidentLog';
 import TracklistDisco from '../components/worlds/disco-ascension/TracklistDisco';
+import ShareCTA from '../components/worlds/disco-ascension/ShareCTA';
 import { heroContent, tracklist, incidentLog } from '../content/discoAscensionData';
 
 export default function DiscoAscension() {
   return (
     <Layout>
       <HeroDisco content={heroContent} />
-      <div className="container space-y-12">
-        <AudioPlayerDisco src="https://example.com/embed" />
+      <div className="container space-y-12 starfield">
+        <AudioPlayerDisco src="https://example.com/audio.mp3" incidents={incidentLog} />
         <IncidentLog log={incidentLog} />
         <TracklistDisco tracks={tracklist} />
       </div>
+      <ShareCTA />
     </Layout>
   );
 }

--- a/src/pages/__tests__/DiscoAscension.test.tsx
+++ b/src/pages/__tests__/DiscoAscension.test.tsx
@@ -12,7 +12,7 @@ describe('DiscoAscension page', () => {
       </MemoryRouter>
     );
     expect(screen.getByRole('heading', { name: /disco ascension/i })).toBeInTheDocument();
-    const toggle = screen.getByRole('button', { name: /show log/i });
+    const toggle = screen.getByRole('button', { name: /access classified research files/i });
     await userEvent.click(toggle);
     expect(screen.getByText(/disco ball manifestation/i)).toBeInTheDocument();
   });

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -39,3 +39,36 @@
 }
 
 .animate-glitch { animation: glitch 1s infinite; }
+
+@keyframes glitch-flicker {
+  0%, 100% { transform: translate(0); }
+  50% { transform: translate(1px, -1px) skew(-0.5deg); }
+}
+
+.animate-glitch-flicker { animation: glitch-flicker 2s infinite; }
+
+.starfield::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(#fff 1px, transparent 1px);
+  background-size: 2px 2px;
+  opacity: 0.1;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.crt-overlay::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  mix-blend-mode: overlay;
+}


### PR DESCRIPTION
## Summary
- style hero with classified banner and warning box
- build audio player with incident timeline overlay
- toggle conspiracy file log with terminal styling
- present tracklist card and share CTA
- add starfield and CRT overlay utilities
- reference ETAB and AlphaTheta memo about Mochakk in site data

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ac46452a08321baad4b8b9ecdafb6