### PR TITLE
Add access denied toast helper

### DIFF
--- a/src/components/worlds/disco-ascension/AlphaThetaCercleLoreBlock.tsx
+++ b/src/components/worlds/disco-ascension/AlphaThetaCercleLoreBlock.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { toast } from '@/components/ui/use-toast';
+import { showAccessDeniedAlert } from '@/lib/alerts'
 
 export default function AlphaThetaCercleLoreBlock() {
   const handleDenied = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    toast({
-      title: 'Access Denied',
-      description: 'You do not have permission to access this resource.',
-    });
-    e.currentTarget.focus();
-  };
+    e.preventDefault()
+    showAccessDeniedAlert()
+    e.currentTarget.focus()
+  }
 
   return (
     <motion.div

--- a/src/lib/alerts.ts
+++ b/src/lib/alerts.ts
@@ -1,0 +1,8 @@
+import { toast } from '@/components/ui/use-toast'
+
+export function showAccessDeniedAlert() {
+  toast({
+    title: 'Access Denied',
+    description: 'You do not have permission to access this resource.'
+  })
+}


### PR DESCRIPTION
## Summary
- provide `showAccessDeniedAlert` helper
- use the helper for leaked links in AlphaThetaCercleLoreBlock

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac5b01a5c83219d3c9746e079d793