### PR TITLE
Add glitch text and starfield CRT styles

### DIFF
--- a/src/components/worlds/disco-ascension/HeroDisco.tsx
+++ b/src/components/worlds/disco-ascension/HeroDisco.tsx
@@ -16,7 +16,10 @@ export default function HeroDisco({ content }: HeroProps) {
         <AlertTriangle className="w-5 h-5 text-red-400" />
         <span className="text-red-300 font-semibold text-sm">CLASSIFIED MATERIAL</span>
       </div>
-      <h1 className="text-heading-1 bg-gradient-to-r from-amber-400 via-orange-500 to-red-500 bg-clip-text text-transparent font-grotesque mb-4">
+      <h1
+        className="text-heading-1 bg-gradient-to-r from-amber-400 via-orange-500 to-red-500 bg-clip-text text-transparent font-grotesque mb-4 glitch-text"
+        data-text={content.title}
+      >
         {content.title}
       </h1>
       <p className="text-heading-2 mb-6">{content.tagline}</p>

--- a/src/pages/DiscoAscension.tsx
+++ b/src/pages/DiscoAscension.tsx
@@ -10,7 +10,7 @@ export default function DiscoAscension() {
   return (
     <Layout>
       <HeroDisco content={heroContent} />
-      <div className="container space-y-12 starfield">
+      <div className="container space-y-12 starfield-crt">
         <AudioPlayerDisco src="https://example.com/audio.mp3" incidents={incidentLog} />
         <IncidentLog log={incidentLog} />
         <TracklistDisco tracks={tracklist} />

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -72,3 +72,62 @@
   );
   mix-blend-mode: overlay;
 }
+
+/* Glitch text effect using existing glitch animation */
+.glitch-text {
+  position: relative;
+  display: inline-block;
+}
+
+.glitch-text::before,
+.glitch-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  animation: glitch 1s infinite;
+  pointer-events: none;
+}
+
+.glitch-text::before {
+  color: rgba(255, 0, 128, 0.7);
+  transform: translate(-2px, 0);
+  z-index: -1;
+}
+
+.glitch-text::after {
+  color: rgba(0, 255, 255, 0.7);
+  transform: translate(2px, 0);
+  z-index: -2;
+}
+
+/* Combined starfield and CRT overlay */
+.starfield-crt {
+  position: relative;
+}
+
+.starfield-crt::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(#fff 1px, transparent 1px);
+  background-size: 2px 2px;
+  opacity: 0.1;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.starfield-crt::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  mix-blend-mode: overlay;
+}


### PR DESCRIPTION
## Summary
- create `.glitch-text` class for animated glitching
- add `.starfield-crt` overlay class combining starfield and CRT scanlines
- apply glitch text to Disco Ascension hero heading
- use `starfield-crt` on Disco Ascension page background container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac680bec88321992f97686c3595c0