### PR TITLE
Refine footer layout and colors

### DIFF
--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -4,24 +4,24 @@ import { Instagram, Facebook, Music, Mail } from "lucide-react";
 
 const Footer = () => {
   return (
-    <footer className="border-t border-foreground/10 bg-background py-12">
-      <div className="mx-auto grid max-w-7xl gap-8 px-4 md:grid-cols-3">
+    <footer role="contentinfo" className="mt-auto border-t border-foreground/10 bg-background py-12">
+      <div className="container mx-auto grid gap-8 px-4 md:grid-cols-3">
         <div className="space-y-4">
           <h3 className="text-heading-2">ZACK BISSELL</h3>
           <p className="text-body text-foreground/70">
             Brooklyn's storytelling DJ & sonic architect. World-class sets, unforgettable journeys.
           </p>
           <div className="flex gap-4">
-            <a href="#" aria-label="Instagram" className="text-foreground/70 hover:text-foreground">
+            <a href="#" aria-label="Instagram" className="text-foreground/70 hover:text-primary">
               <Instagram className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Facebook" className="text-foreground/70 hover:text-foreground">
+            <a href="#" aria-label="Facebook" className="text-foreground/70 hover:text-primary">
               <Facebook className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Music" className="text-foreground/70 hover:text-foreground">
+            <a href="#" aria-label="Music" className="text-foreground/70 hover:text-primary">
               <Music className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Email" className="text-foreground/70 hover:text-foreground">
+            <a href="#" aria-label="Email" className="text-foreground/70 hover:text-primary">
               <Mail className="h-6 w-6" />
             </a>
           </div>
@@ -30,16 +30,16 @@ const Footer = () => {
         <div className="space-y-4">
           <h4 className="text-heading-2">Quick Links</h4>
           <div className="space-y-2">
-            <a href="/booking" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/booking" className="block text-body text-foreground/70 hover:text-primary">
               Book Zack
             </a>
-            <a href="/about" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/about" className="block text-body text-foreground/70 hover:text-primary">
               EPK/Bio
             </a>
-            <a href="/press" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/press" className="block text-body text-foreground/70 hover:text-primary">
               Press Kit
             </a>
-            <a href="/lab-obsidian" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/lab-obsidian" className="block text-body text-foreground/70 hover:text-primary">
               Lab Obsidian
             </a>
           </div>
@@ -48,16 +48,16 @@ const Footer = () => {
         <div className="space-y-4">
           <h4 className="text-heading-2">Featured Worlds</h4>
           <div className="space-y-2">
-            <a href="/disco-ascension" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/disco-ascension" className="block text-body text-foreground/70 hover:text-primary">
               Disco Ascension
             </a>
-            <a href="/nostalgia-trap" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/nostalgia-trap" className="block text-body text-foreground/70 hover:text-primary">
               Nostalgia Trap
             </a>
-            <a href="/house-work" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/house-work" className="block text-body text-foreground/70 hover:text-primary">
               House Work
             </a>
-            <a href="/role-model" className="block text-body text-foreground/70 hover:text-foreground">
+            <a href="/role-model" className="block text-body text-foreground/70 hover:text-primary">
               Role Model
             </a>
           </div>
@@ -65,7 +65,7 @@ const Footer = () => {
       </div>
 
       <div className="mt-8 border-t border-foreground/10 pt-8 text-center">
-        <p className="text-subtle">© 2024 Zack Bissell. All rights reserved.</p>
+        <p className="text-sm text-foreground/70">© 2024 Zack Bissell. All rights reserved.</p>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- center footer content with `mt-auto` and `container mx-auto`
- add semantic role to footer
- soften copy and links with `text-foreground/70`
- use primary color on hover for footer links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ad9e5d0a48321990f2bdc3d90dfc0