### PR TITLE
Improve text color contrast

### DIFF
--- a/src/components/global/Footer.tsx
+++ b/src/components/global/Footer.tsx
@@ -8,20 +8,20 @@ const Footer = () => {
       <div className="container mx-auto grid gap-8 px-4 md:grid-cols-3">
         <div className="space-y-4">
           <h3 className="text-heading-2">ZACK BISSELL</h3>
-          <p className="text-body text-foreground/70">
+          <p className="text-body text-foreground-secondary">
             Brooklyn's storytelling DJ & sonic architect. World-class sets, unforgettable journeys.
           </p>
           <div className="flex gap-4">
-            <a href="#" aria-label="Instagram" className="text-foreground/70 hover:text-primary">
+            <a href="#" aria-label="Instagram" className="text-foreground-secondary hover:text-primary">
               <Instagram className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Facebook" className="text-foreground/70 hover:text-primary">
+            <a href="#" aria-label="Facebook" className="text-foreground-secondary hover:text-primary">
               <Facebook className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Music" className="text-foreground/70 hover:text-primary">
+            <a href="#" aria-label="Music" className="text-foreground-secondary hover:text-primary">
               <Music className="h-6 w-6" />
             </a>
-            <a href="#" aria-label="Email" className="text-foreground/70 hover:text-primary">
+            <a href="#" aria-label="Email" className="text-foreground-secondary hover:text-primary">
               <Mail className="h-6 w-6" />
             </a>
           </div>
@@ -30,16 +30,16 @@ const Footer = () => {
         <div className="space-y-4">
           <h4 className="text-heading-2">Quick Links</h4>
           <div className="space-y-2">
-            <a href="/booking" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/booking" className="block text-body text-foreground-secondary hover:text-primary">
               Book Zack
             </a>
-            <a href="/about" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/about" className="block text-body text-foreground-secondary hover:text-primary">
               EPK/Bio
             </a>
-            <a href="/press" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/press" className="block text-body text-foreground-secondary hover:text-primary">
               Press Kit
             </a>
-            <a href="/lab-obsidian" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/lab-obsidian" className="block text-body text-foreground-secondary hover:text-primary">
               Lab Obsidian
             </a>
           </div>
@@ -48,16 +48,16 @@ const Footer = () => {
         <div className="space-y-4">
           <h4 className="text-heading-2">Featured Worlds</h4>
           <div className="space-y-2">
-            <a href="/disco-ascension" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/disco-ascension" className="block text-body text-foreground-secondary hover:text-primary">
               Disco Ascension
             </a>
-            <a href="/nostalgia-trap" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/nostalgia-trap" className="block text-body text-foreground-secondary hover:text-primary">
               Nostalgia Trap
             </a>
-            <a href="/house-work" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/house-work" className="block text-body text-foreground-secondary hover:text-primary">
               House Work
             </a>
-            <a href="/role-model" className="block text-body text-foreground/70 hover:text-primary">
+            <a href="/role-model" className="block text-body text-foreground-secondary hover:text-primary">
               Role Model
             </a>
           </div>
@@ -65,7 +65,7 @@ const Footer = () => {
       </div>
 
       <div className="mt-8 border-t border-foreground/10 pt-8 text-center">
-        <p className="text-sm text-foreground/70">© 2024 Zack Bissell. All rights reserved.</p>
+        <p className="text-sm text-foreground-secondary">© 2024 Zack Bissell. All rights reserved.</p>
       </div>
     </footer>
   );

--- a/src/components/global/Navigation.tsx
+++ b/src/components/global/Navigation.tsx
@@ -37,7 +37,7 @@ const Navigation = () => {
               className={`text-body transition-colors ${
                 location.pathname === item.path
                   ? "text-primary"
-                  : "text-foreground/70 hover:text-primary"
+                  : "text-foreground-secondary hover:text-primary"
               }`}
             >
               {item.label}
@@ -49,7 +49,7 @@ const Navigation = () => {
           <SheetTrigger asChild>
             <button
               aria-label="Open menu"
-              className="md:hidden p-2 text-foreground/80 hover:text-foreground"
+              className="md:hidden p-2 text-foreground-secondary hover:text-foreground"
             >
               <Menu className="h-6 w-6" />
             </button>
@@ -63,7 +63,7 @@ const Navigation = () => {
                   className={`text-base font-medium transition-colors ${
                     location.pathname === item.path
                       ? "text-primary"
-                      : "text-foreground/70 hover:text-primary"
+                      : "text-foreground-secondary hover:text-primary"
                   }`}
                 >
                   {item.label}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground-tertiary opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -7,7 +7,10 @@
 @layer base {
   :root {
     --background: 0 0% 5%;
-    --foreground: 0 0% 95%;
+    /* Apple HIG inspired text colors */
+    --foreground: 240 5% 96%; /* Primary text on dark backgrounds (#F5F5F7) */
+    --foreground-secondary: 240 3% 64%; /* Secondary text (#A1A1A6) */
+    --foreground-tertiary: 240 2% 44%; /* Tertiary text (#6E6E73) */
     --primary: 210 100% 50%;
     --primary-foreground: 0 0% 100%;
   }
@@ -21,7 +24,7 @@
   .text-heading-1 { @apply text-4xl md:text-6xl font-heading font-bold tracking-tighter; }
   .text-heading-2 { @apply text-3xl md:text-4xl font-heading font-semibold tracking-tight; }
   .text-body { @apply text-base font-sans font-normal leading-relaxed; }
-  .text-subtle { @apply text-sm text-foreground/70; }
+  .text-subtle { @apply text-sm text-foreground-secondary; }
   .content-container { @apply mx-auto max-w-7xl px-6; }
   .section-padding { @apply py-20; }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,6 +20,8 @@ const config: Config = {
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        "foreground-secondary": "hsl(var(--foreground-secondary))",
+        "foreground-tertiary": "hsl(var(--foreground-tertiary))",
         primary: {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))"


### PR DESCRIPTION
## Summary
- update color variables to align with Apple HIG
- expose secondary and tertiary text colors to Tailwind
- use new text colors in navigation, footer and toast components

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684aea9bb1448321a6f788c56ec6e1c2